### PR TITLE
refactor: update zkvm dependencies

### DIFF
--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::{fs, io::Write};
-use zkvm::zkvm_evm_generate_chunks;
+use zkvm::zkvm_generate_chunks;
 
 use statedb::database::Database as StateDB;
 use storage_layout_extractor::watchdog::LazyWatchdog;
@@ -495,7 +495,7 @@ pub async fn batch_process(
     );
     log::debug!("workspace: {}", workspace);
     let bootloader_inputs =
-        zkvm_evm_generate_chunks(workspace.as_str(), &suite_json, output_path.as_str()).unwrap();
+        zkvm_generate_chunks(workspace.as_str(), &suite_json, output_path.as_str()).unwrap();
     let cnt_chunks: usize = bootloader_inputs.len();
     log::debug!("Generated {} chunks", cnt_chunks);
     // save the chunks
@@ -534,8 +534,7 @@ mod tests {
         let output_path = format!("../prover/data/proof/{}/{}", task_id, task);
         let workspace = format!("program/{}", task);
         let bootloader_inputs =
-            zkvm_evm_generate_chunks(workspace.as_str(), &suite_json, output_path.as_str())
-                .unwrap();
+            zkvm_generate_chunks(workspace.as_str(), &suite_json, output_path.as_str()).unwrap();
         let cnt_chunks: usize = bootloader_inputs.len();
         log::debug!("Generated {} chunks", cnt_chunks);
         // save the chunks

--- a/prover/src/provers/batch_prover.rs
+++ b/prover/src/provers/batch_prover.rs
@@ -8,7 +8,7 @@ use dsl_compile::circom_compiler;
 use recursion::{compressor12_exec::exec, compressor12_setup::setup};
 use starky::prove::stark_prove;
 use std::{fs, io::Read};
-use zkvm::zkvm_evm_prove_only;
+use zkvm::zkvm_prove_only;
 
 #[derive(Default)]
 pub struct BatchProver {}
@@ -58,7 +58,7 @@ impl Prover<BatchContext> for BatchProver {
             *out = GoldilocksField::from_bytes_le(bin);
         });
 
-        zkvm_evm_prove_only(
+        zkvm_prove_only(
             &ctx.task_name,
             &serde_data,
             bi,


### PR DESCRIPTION
The functions of zkvm are broken and updated.
We need to change the corresponding calling in eigen-prover.
